### PR TITLE
01_einführung-von-wendrivermanager:

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>io.github.bonigarcia</groupId>
+            <artifactId>webdrivermanager</artifactId>
+            <version>5.9.2</version>
+        </dependency>
 
         <!-- Annotations and Utility Libraries -->
         <dependency>

--- a/src/main/java/org/browser/automation/core/access/cache/AbstractWebDriverCacheManager.java
+++ b/src/main/java/org/browser/automation/core/access/cache/AbstractWebDriverCacheManager.java
@@ -1,5 +1,6 @@
 package org.browser.automation.core.access.cache;
 
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.browser.automation.core.annotation.CacheLock;
@@ -41,6 +42,7 @@ import java.util.Optional;
 @Getter
 public abstract class AbstractWebDriverCacheManager implements WebDriverCacheManager {
 
+    @Getter(AccessLevel.PROTECTED)
     private final WebDriverCache webDriverCache;
 
     /**

--- a/src/main/java/org/browser/automation/core/main/MainClass.java
+++ b/src/main/java/org/browser/automation/core/main/MainClass.java
@@ -1,6 +1,13 @@
 package org.browser.automation.core.main;
 
 import lombok.extern.slf4j.Slf4j;
+import org.browser.automation.core.BrowserLauncher;
+import org.browser.automation.exception.BrowserManagerNotInitializedException;
+import org.browser.automation.exception.EssentialFieldsNotSetException;
+import org.browser.automation.exception.NoBrowserConfiguredException;
+import org.openqa.selenium.WebDriver;
+
+import java.util.List;
 
 @Slf4j
 class MainClass {
@@ -11,7 +18,22 @@ class MainClass {
      *
      * @param args command-line arguments (not used).
      */
-    public static void main(String[] args) {
-        System.out.println("TEST");
+    public static void main(String[] args) throws EssentialFieldsNotSetException, NoBrowserConfiguredException, BrowserManagerNotInitializedException {
+
+        BrowserLauncher launcher = BrowserLauncher.builder()
+                .withNewBrowserManager()
+                .withDefaultBrowser() // Set the default browser to be used
+                .urls(List.of("https://example.com", "https://www.google.com"))  // Define the URLs to be opened
+                .withDefaultOptions()
+                .autoCleanUp()
+                .build();
+
+        // Execute the configured browser operations
+        List<WebDriver> drivers = launcher.validateAndExecute();
+
+        // Output and close
+        drivers.forEach(driver -> log.info(driver.toString()));
+
+        System.exit(0);
     }
 }

--- a/src/main/java/org/browser/automation/exception/BrowserManagerNotInitializedException.java
+++ b/src/main/java/org/browser/automation/exception/BrowserManagerNotInitializedException.java
@@ -1,0 +1,29 @@
+package org.browser.automation.exception;
+
+import org.browser.automation.exception.base.LocalizedExceptionBase;
+
+/**
+ * Exception thrown when the BrowserManager is not initialized before performing operations that require it.
+ * This exception is designed to indicate that the BrowserManager must be set using the appropriate methods
+ * before invoking operations that depend on it.
+ */
+public class BrowserManagerNotInitializedException extends LocalizedExceptionBase {
+
+    /**
+     * Constructs a new {@code BrowserManagerNotInitializedException} with a detailed message
+     * indicating that the BrowserManager was not initialized.
+     */
+    public BrowserManagerNotInitializedException() {
+        super("exception.browser.manager.not.initialized");
+    }
+
+    /**
+     * Constructs a new {@code BrowserManagerNotInitializedException} with a custom message
+     * explaining the cause of the exception.
+     *
+     * @param customMessage a custom message explaining the cause of the exception.
+     */
+    public BrowserManagerNotInitializedException(String customMessage) {
+        super(customMessage, "exception.browser.manager.not.initialized.custom");
+    }
+}

--- a/src/main/java/org/browser/automation/utils/ByteBuddyUtils.java
+++ b/src/main/java/org/browser/automation/utils/ByteBuddyUtils.java
@@ -18,22 +18,23 @@ public class ByteBuddyUtils {
 
     /**
      * Dynamically creates an instance of a class using ByteBuddy with method interception.
+     * This method allows the creation of a subclass of the specified target class, where
+     * specified methods are intercepted and handled by the provided handler instance.
      *
      * @param <T>             the type of the class to be created.
      * @param targetClass     the class to be subclassed and dynamically instantiated.
-     *                        #ANPASSEN
      * @param handlerInstance the instance of the handler that will process the intercepted methods.
-     * @param matcher         an {@link ElementMatcher} that defines which methods to intercept.
+     * @param matcher         an {@link ElementMatcher} that defines which methods to intercept in the target class.
      * @return the dynamically created instance of the specified class.
-     * @throws NoSuchMethodException     if the specified method cannot be found.
-     * @throws InvocationTargetException if the underlying method throws an exception.
-     * @throws InstantiationException    if the class that declares the underlying constructor represents an abstract class.
-     * @throws IllegalAccessException    if the underlying method or constructor is inaccessible.
+     * @throws NoSuchMethodException     if the specified constructor cannot be found.
+     * @throws InvocationTargetException if the underlying constructor throws an exception.
+     * @throws InstantiationException    if the class that declares the underlying constructor is abstract.
+     * @throws IllegalAccessException    if the underlying constructor is inaccessible.
      */
     public <T> T createInstance(Class<T> targetClass, Object handlerInstance, ElementMatcher<? super MethodDescription> matcher)
             throws NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
 
-        // Erstellen der dynamischen Subklasse und Intercepting der Methoden
+        // Create a dynamic subclass and intercept methods as specified by the matcher
         return new ByteBuddy()
                 .subclass(targetClass)
                 .method(matcher)

--- a/src/main/resources/context/messages.properties
+++ b/src/main/resources/context/messages.properties
@@ -33,3 +33,7 @@ exception.webdriver.comparison.error.custom={1} (WebDriver Instance: {0})
 # NoBrowserConfiguredException messages
 exception.browser.not.configured=No browser has been configured in the BrowserLauncher. Detail: {0}
 exception.browser.not.configured.custom={1} (Custom Message: No browser has been configured. Detail: {0})
+
+# BrowserManagerNotInitializedException messages
+exception.browser.manager.not.initialized=The BrowserManager instance has not been initialized. Please use the withNewBrowserManager method to set it before calling other methods.
+exception.browser.manager.not.initialized.custom={0} (BrowserManager: Not Initialized)


### PR DESCRIPTION
AbstractWebDriverCacheManager
- getWebDriverCache() wurde aus Sicherheitsgründen privatisiert BrowserDetector
- Einführen des WebDriverManagers von io.github.bonigarcia.wdm
- Anpassen der Dokumentationen BrowserManagerNotInitializedException
- Erstellen einer neuen Exception zur Sicherstellung der Reihenfolge von Befehlsaufrufen in BrowserLauncher ByteBuddyUtils
- Anpassen der Dokumentation MainClass
- Rückführung der Main-Methode